### PR TITLE
Fixed course homepage link

### DIFF
--- a/hw01/README.md
+++ b/hw01/README.md
@@ -5,7 +5,7 @@
 Please ask questions on Piazza (Penn students) or Google Groups (other).
 Links on [course homepage].
 
-[course homepage]: cis198-2016f.github.io
+[course homepage]: //cis198-2016f.github.io
 
 ## Overview
 


### PR DESCRIPTION
Without the protocol, GitHub doesn't like to format things as links.
